### PR TITLE
Add support for distro specific site restore callbacks

### DIFF
--- a/classes/site_restore.php
+++ b/classes/site_restore.php
@@ -448,6 +448,13 @@ class site_restore extends operation_base {
                 }
             }
 
+            // Distribution callback if present.
+            if (class_exists('core\distribution')) {
+                if (is_callable(['core\distribution', 'tool_vault_after_table_restore'])) {
+                    \core\distribution::tool_vault_after_table_restore($tablename);
+                }
+            }
+
             // Restore preserved data, apply config overrides, reset admin password, etc.
             $this->after_table_restore($table, $preserveddata);
 


### PR DESCRIPTION
Hi Marina, here is another more neutral patch adding support for custom site restore callbacks.

This is an example of the new \core\distribution class:

```

namespace core;

final class distribution {    
    /**
     * Callback for site restore/migration executed after each database table.
     *
     * @param string $tablename
     * @return void
     */
    public static function tool_vault_after_table_restore(string $tablename): void {
        global $DB;

        if ($tablename !== 'context') {
            return;
        }

        $dbman = $DB->get_manager();

        $table = new \xmldb_table('context');
        $field = new \xmldb_field('tenantid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
        if (!$dbman->field_exists($table, $field)) {
            $dbman->add_field($table, $field);
            $index = new \xmldb_index('tenantid', XMLDB_INDEX_NOTUNIQUE, ['tenantid']);
            $dbman->add_index($table, $index);
        }
    }
}

```